### PR TITLE
URI Connection Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: node_js
+node_js:
+  - 0.11
+  - 0.10
+services: mongodb
+

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ persistence.
 If you're using this module, feel free to contact me on twitter if you
 have any questions! :) [@rjrodger](http://twitter.com/rjrodger)
 
-Current Version: 0.1.10
+Current Version: 0.2.0
 
-Tested on: Node 0.10.29, Seneca 0.5.18
+Tested on: Node 0.10.36, Seneca 0.6.1
 
 
 

--- a/mongo-store.js
+++ b/mongo-store.js
@@ -109,7 +109,6 @@ module.exports = function(opts) {
 
   function configure(spec,cb) {
     specifications = spec
-    console.log("\n\n\n",spec,"\n\n\n")
     // defer connection
     // TODO: expose connection action
     if( !_.isUndefined(spec.connect) && !spec.connect ) {

--- a/mongo-store.js
+++ b/mongo-store.js
@@ -1,8 +1,8 @@
-/* Copyright (c) 2010-2014 Richard Rodger, MIT License */
+/* Copyright (c) 2010-2015 Richard Rodger, MIT License */
 "use strict";
 
 
-var _     = require('underscore')
+var _     = require('lodash')
 var mongo = require('mongodb')
 
 

--- a/mongo-store.js
+++ b/mongo-store.js
@@ -127,14 +127,16 @@ module.exports = function(opts) {
 
     // Extend the db options with some defaults
     // See http://mongodb.github.io/node-mongodb-native/2.0/reference/connecting/connection-settings/ for options
-    var dbopts = seneca.util.deepextend({
-      native_parser:false,
-      auto_reconnect:true,
-      w:1
+    var options = seneca.util.deepextend({
+      db: {},
+      server: {},
+      replset: {},
+      mongos: {}
     }, conf.options)
 
+
     // Connect using the URI
-    MongoClient.connect(conf.uri, dbopts, function(err, db) {
+    MongoClient.connect(conf.uri, options, function(err, db) {
       if (err) {
         return seneca.die('connect', err, conf);
       }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seneca-mongo-store",
-  "version": "0.1.10",
+  "version": "0.2.0",
   "description": "Seneca data store plugin for MongoDB",
   "main": "mongo-store.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -27,17 +27,14 @@
   ],
   "license": "MIT",
   "dependencies": {
-    "underscore": "~1.6.0",
-    "mongodb": "~1.4.7"
+    "lodash": "~2.4.1",
+    "mongodb": "~1.4.30"
   },
   "devDependencies": {
     "async": "~0.9.0",
-    "seneca": "~0.5.20",
+    "seneca": "plugin",
     "mocha": "~1.20.1",
     "seneca-store-test": "~0.2.2"
-  },
-  "peerDependencies": {
-    "seneca": "*"
   },
   "files": [
     "LICENSE.txt",

--- a/test/mongo.test.js
+++ b/test/mongo.test.js
@@ -1,4 +1,4 @@
-/* Copyright (c) 2010-2014 Richard Rodger */
+/* Copyright (c) 2010-2015 Richard Rodger */
 "use strict";
 
 


### PR DESCRIPTION
Now use `.connect` along with URI strings for connecting and passing options to native MongoDB driver.