### PR TITLE
Fix Quick Example

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,10 +42,10 @@ npm install seneca-mongo-store
 
 ```js
 var seneca = require('seneca')()
-seneca.use('mongo-store', {
+seneca.use("entity")
+.use('mongo-store', {
   uri: 'mongodb://120.0.0.1:27017/dbname'
 })
-.use("entity")
 
 seneca.ready(function () {
   var apple = seneca.make$('fruit')


### PR DESCRIPTION
The Quick Example in README.md was not working property.

Run of the original quick example:
```
$ node app.js 
{"kind":"notice","notice":"hello seneca 8wmccxmk7cmf/1495297912507/31942/3.3.0/-","level":"info","when":1495297912778}
apple.id = jd63w4
```

The code works without errors, but nothing is stored in mongo.
Also the apple id is not a mongo ObjectID.

After including `entity` before `mongo-store`:

```
$ node app.js 
{"kind":"notice","notice":"hello seneca vezorrlgwebm/1495297952770/31943/3.3.0/-","level":"info","when":1495297952983}
apple.id = 59206fa0557c837cc74817b7
```

The apple is stored in the collection fruit and it contains a mongo ObjectID.

Environment:
node: 7.10.0.
mongo: 3.2.0.
seneca: 3.3.0
seneca-entity: 2.0.0
seneca-mongo-store: 1.1.0