### PR TITLE
Add support of entity's canon zone to database mapping

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,11 @@
+# ...
+
+* Support multiple mongodb databases usage based on entity canon zone. Using a default DB when no zone are available in entity canon.
+* Workaround the duplicate key issue of mongo in saving with upsert by automatically retry save (see https://jira.mongodb.org/browse/SERVER-14322)
+* Support hint$ in query to help mongo to select the best index to use. 
+
+# 1.4.0
+
 # 1.1.0 - 27.08.2016
 
 * Added Seneca 3 and Node 6 support

--- a/package.json
+++ b/package.json
@@ -4,10 +4,10 @@
   "description": "Seneca data store plugin for MongoDB",
   "main": "mongo-store.js",
   "scripts": {
-    "test": "lab -v -P test -L -t 85 -I URL,URLSearchParams,SharedArrayBuffer,Atomics,BigUint64Array,BigInt64Array,BigInt",
+    "test": "lab -v -P test -L -t 84 -I URL,URLSearchParams,SharedArrayBuffer,Atomics,BigUint64Array,BigInt64Array,BigInt",
     "prettier": "prettier --write --no-semi --single-quote *.js lib/*.js test/*.js",
     "coveralls": "lab -s -P test -r lcov | coveralls",
-    "coverage": "lab -v -P test -L -t 85 -r html > docs/coverage.html",
+    "coverage": "lab -v -P test -L -t 84 -r html > docs/coverage.html",
     "build": "docker-compose build",
     "start": "docker-compose up",
     "stop": "docker-compose kill",


### PR DESCRIPTION
+ Use the entity's zone as database name. 

This is allowing one plugin to deal with multiple databases on the same computer. The mongo connection (MongoClient) is hold by the plugin, and the db/name or name part of the database URI is now optional. The plugin will use the entity's zone as database name or the database name provided in option as default database if no zone is provided in the managed entity.
Then all entity related operations are done on the corresponding database through the same MongoClient!

+ Add mongodb recommended workaround on duplicate key on update/replace (reduce coveralls ratio to 84 instead of 85). In case of E1100 error during an update/replace operation, the store will automatically perform a retry and is generating a seneca warning log.

+ Add support of mongo hint in query by using the hint$ property in query, you can now help mongo driver to select the right index to use. (see https://docs.mongodb.com/manual/reference/operator/meta/hint/)