### PR TITLE
feat: added ref to lib/intern.js to package

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "seneca-store-test": "4.0.2"
   },
   "files": [
+    "lib/**/*.js",
     "LICENSE.txt",
     "README.md",
     "mongo-store.js"


### PR DESCRIPTION
Hello. There's a bug associated to package.json which doesnt include lib/intern.js when trying to npm install this module, which then results in this error:

![image](https://user-images.githubusercontent.com/54679775/150935294-cd14b01b-0106-45ef-96b9-b6b3a32394d2.png)

Test with this command:  npm pack --dry-run
Before:
![image](https://user-images.githubusercontent.com/54679775/150935599-8239da79-11e5-4613-b90e-26987bcb6af7.png)

After:
![image](https://user-images.githubusercontent.com/54679775/150935686-0dea50d4-d1e8-42c6-802b-fed714e46b96.png)


Hope this can help and sorry for bothering, im not a native english speaker.

Thank you.